### PR TITLE
Fix typo in URL

### DIFF
--- a/component/templates/_package.json
+++ b/component/templates/_package.json
@@ -16,7 +16,7 @@
   "bugs": {
     "url": "https://github.com/eHealthAfrica/<%= name %>/issues"
   },
-  "homepage": "http://ehealtharfica.org",
+  "homepage": "http://ehealthafrica.org",
   "devDependencies": {
     "angular": "^1.3.13",
     "angular-mocks": "^1.3.13",


### PR DESCRIPTION
Just saw that this is actually in the generator, not in the specific components. We have to fix that in every released components than :)
