### PR TITLE
fix(generator): karma coverage location fixed

### DIFF
--- a/component/templates/_karma.conf.js
+++ b/component/templates/_karma.conf.js
@@ -30,7 +30,7 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      'lib/**/*.js': 'coverage'
+      'src/**/*.js': 'coverage'
     },
 
     // test results reporter to use


### PR DESCRIPTION
Karma was looking in lib/ for *.js files for coverage, when the generator puts the files in src/. So I fixed that.

@tthew wanna peer review (tiny change)? I also noticed that develop is not up to date (assuming gitflow type development process).
